### PR TITLE
Render variants returned by resgen-server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ es
 *.log
 *.DS_cache
 *.DS_Store
+*.bak

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "higlass-pileup",
-  "version": "0.5.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/PileupTrack.js
+++ b/src/PileupTrack.js
@@ -582,6 +582,7 @@ varying vec4 vColor;
                   }
 
                   let mouseOverHtml =
+                    `ID: ${read.id}<br>` +
                     `Position: ${read.chrName}:${
                       read.from - read.chrOffset
                     }<br>` +
@@ -613,7 +614,7 @@ varying vec4 vColor;
         ) {
           const mousePos = this._xScale.invert(trackX);
           let bpIndex = Math.floor(mousePos);
-          bpIndex = bpIndex - bpIndex % this.coverageSamplingDistance;
+          bpIndex = bpIndex - (bpIndex % this.coverageSamplingDistance);
           if (this.coverage[bpIndex]) {
             const readCount = this.coverage[bpIndex];
             const matchPercent = (readCount.matches / readCount.reads) * 100;

--- a/src/PileupTrack.js
+++ b/src/PileupTrack.js
@@ -904,6 +904,19 @@ PileupTrack.config = {
         },
       },
     },
+    showCoverage: {
+      name: 'Show coverage',
+      inlineOptions: {
+        yes: {
+          value: true,
+          name: 'Yes',
+        },
+        no: {
+          value: false,
+          name: 'No',
+        },
+      },
+    },
     groupBy: {
       name: 'Group by',
       inlineOptions: {

--- a/src/bam-fetcher-worker.js
+++ b/src/bam-fetcher-worker.js
@@ -193,21 +193,47 @@ const bamRecordToJson = (bamRecord, chrName, chrOffset) => {
     substitutions: [],
   };
 
-  segment['substitutions'] = getSubstitutions(segment, seq);
+  segment.substitutions = getSubstitutions(segment, seq);
 
   return segment;
 };
 
+/** Convert mapped read information returned from a higlass
+    server to the internal track representation. This method is
+    the counterpart to bamRecordToJson */
 const tabularJsonToRowJson = (tabularJson) => {
   const rowJson = [];
 
   const headers = Object.keys(tabularJson);
 
   for (let i = 0; i < tabularJson[headers[0]].length; i++) {
-    const newRow = {};
+    const newRow = {
+      row: null,
+      substitutions: [],
+    };
 
     for (let j = 0; j < headers.length; j++) {
       newRow[headers[j]] = tabularJson[headers[j]][i];
+    }
+
+    newRow.from += 1;
+
+    if (newRow.variants) {
+      newRow.substitutions = newRow.variants.map((x) => ({
+        pos: x[1] - (newRow.from - newRow.chrOffset) + 1,
+        variant: x[2].toUpperCase(),
+        length: 1,
+      }));
+    }
+
+    if (newRow.cigars) {
+      for (let x of newRow.cigars) {
+        newRow.substitutions.push({
+          pos: x[1] - (newRow.from - newRow.chrOffset) + 1,
+          type: x[2].toUpperCase(),
+          length: x[3],
+        });
+      }
     }
 
     rowJson.push(newRow);
@@ -302,9 +328,9 @@ const getCoverage = (segmentList, samplingDistance) => {
     const from = segmentList[j].from;
     const to = segmentList[j].to;
     // Find the first position that is in the sampling set
-    const firstFrom = from - from % samplingDistance + samplingDistance;
+    const firstFrom = from - (from % samplingDistance) + samplingDistance;
 
-    for (let i = firstFrom; i < to; i=i+samplingDistance) {
+    for (let i = firstFrom; i < to; i = i + samplingDistance) {
       if (!coverage[i]) {
         coverage[i] = {
           reads: 0,
@@ -322,11 +348,11 @@ const getCoverage = (segmentList, samplingDistance) => {
       coverage[i].matches++;
       maxCoverage = Math.max(maxCoverage, coverage[i].reads);
     }
-            
+
     segmentList[j].substitutions.forEach((substitution) => {
       if (substitution.variant) {
         const posSub = from + substitution.pos;
-        if(!coverage[posSub]){
+        if (!coverage[posSub]) {
           return;
         }
         coverage[posSub].matches--;
@@ -593,7 +619,7 @@ function assignSegmentToRow(segment, occupiedSpaceInRows, padding) {
   const segmentToWithPadding = segment.to + padding;
 
   // no row has been assigned - find a suitable row and update the occupied space
-  if (segment.row === null) {
+  if (segment.row === null || segment.row === undefined) {
     // Go through each row and look if there is space for the segment
     for (let i = 0; i < occupiedSpaceInRows.length; i++) {
       if (!occupiedSpaceInRows[i]) {
@@ -704,6 +730,7 @@ function segmentsToRows(segments, optionsIn) {
   for (let i = 0; i < occupiedSpaceInRows.length; i++) {
     outputRows[i] = newSegments.filter((x) => x.row === i);
   }
+
   return outputRows;
 }
 
@@ -878,9 +905,11 @@ const renderSegments = (
   }
 
   if (trackOptions.showCoverage) {
-    
     const maxCoverageSamples = 10000;
-    coverageSamplingDistance = Math.max(Math.floor((maxPos - minPos) / maxCoverageSamples), 1);
+    coverageSamplingDistance = Math.max(
+      Math.floor((maxPos - minPos) / maxCoverageSamples),
+      1,
+    );
     const result = getCoverage(segmentList, coverageSamplingDistance);
 
     allReadCounts = result.coverage;
@@ -896,7 +925,7 @@ const renderSegments = (
 
     let xLeft, yTop, barHeight;
     let bgColor = PILEUP_COLOR_IXS.BG_MUTED;
-    const width = (xScale(1) - xScale(0))*coverageSamplingDistance;
+    const width = (xScale(1) - xScale(0)) * coverageSamplingDistance;
     const groupHeight = yScale.bandwidth() * trackOptions.coverageHeight;
     const scalingFactor = groupHeight / maxReadCount;
 
@@ -916,10 +945,10 @@ const renderSegments = (
 
       barHeight = allReadCounts[pos]['matches'] * scalingFactor;
       yTop -= barHeight;
-      if(coverageSamplingDistance === 1){
+      if (coverageSamplingDistance === 1) {
         bgColor = pos % 2 === 0 ? PILEUP_COLOR_IXS.BG : PILEUP_COLOR_IXS.BG2;
       }
-      
+
       addRect(xLeft, yTop, width, barHeight, bgColor);
     }
   }
@@ -1074,7 +1103,7 @@ const renderSegments = (
 
   //const t2 = currTime();
   //console.log('renderSegments time:', t2 - t1, 'ms');
-  
+
   return Transfer(objData, [objData.positionsBuffer, colorsBuffer, ixBuffer]);
 };
 

--- a/src/bam-utils.js
+++ b/src/bam-utils.js
@@ -26,20 +26,20 @@ Object.keys(PILEUP_COLORS).map((x, i) => {
 });
 
 export const cigarTypeToText = (type) => {
-  if(type === "D"){
-    return "Deletion";
-  } else if(type === "S"){
-    return "Soft clipping";
-  } else if(type === "H"){
-    return "Hard clipping";
-  } else if(type === "I"){
-    return "Insertion";
-  } else if(type === "N"){
-    return "Skipped region";
-  } else {
-    return type;
+  if (type === 'D') {
+    return 'Deletion';
+  } else if (type === 'S') {
+    return 'Soft clipping';
+  } else if (type === 'H') {
+    return 'Hard clipping';
+  } else if (type === 'I') {
+    return 'Insertion';
+  } else if (type === 'N') {
+    return 'Skipped region';
   }
-}
+
+  return type;
+};
 
 export const parseMD = (mdString, useCounts) => {
   let currPos = 0;
@@ -53,19 +53,19 @@ export const parseMD = (mdString, useCounts) => {
       // a number, keep on going
       currNum = currNum * 10 + +mdString[i];
       deletionEncountered = false;
-    }else if(mdString[i] === "^"){
+    } else if (mdString[i] === '^') {
       deletionEncountered = true;
     } else {
-
       currPos += currNum;
-      
+
       if (useCounts) {
         substitutions.push({
           length: currNum,
           type: mdString[i],
         });
-      } else if(deletionEncountered){
-        // Do nothing if there is a deletion and keep on going. Note that there can be multiple deletions "^ATC"
+      } else if (deletionEncountered) {
+        // Do nothing if there is a deletion and keep on going.
+        // Note that there can be multiple deletions "^ATC"
         // Deletions are visualized using the CIGAR string
         // However, keep track of where in the bam seq we need to pull the variant.
         bamSeqShift -= 1;
@@ -74,7 +74,7 @@ export const parseMD = (mdString, useCounts) => {
           pos: currPos,
           base: mdString[i],
           length: 1,
-          bamSeqShift: bamSeqShift,
+          bamSeqShift,
         });
       }
 
@@ -82,16 +82,16 @@ export const parseMD = (mdString, useCounts) => {
       currPos += 1;
     }
   }
-  
+
   return substitutions;
 };
 
 /**
-   * Gets an array of all substitutions in the segment
-   * @param  {String} segment  Current segment
-   * @param  {String} seq   Read sequence from bam file.
-   * @return {Array}  Substitutions.
-   */
+ * Gets an array of all substitutions in the segment
+ * @param  {String} segment  Current segment
+ * @param  {String} seq   Read sequence from bam file.
+ * @return {Array}  Substitutions.
+ */
 export const getSubstitutions = (segment, seq) => {
   let substitutions = [];
   let softClippingAtReadStart = null;
@@ -114,7 +114,7 @@ export const getSubstitutions = (segment, seq) => {
       } else if (sub.type === 'I') {
         substitutions.push({
           pos: currPos,
-          length: 0.1,
+          length: sub.length,
           type: 'I',
         });
       } else if (sub.type === 'D') {
@@ -159,7 +159,7 @@ export const getSubstitutions = (segment, seq) => {
         type: 'S',
         length: firstSub.length,
       });
-    } 
+    }
     // soft clipping at the end
     if (lastSub.type === 'S') {
       substitutions.push({
@@ -177,7 +177,7 @@ export const getSubstitutions = (segment, seq) => {
         type: 'H',
         length: firstSub.length,
       });
-    } 
+    }
     if (lastSub.type === 'H') {
       substitutions.push({
         pos: segment.to - segment.from,
@@ -187,22 +187,21 @@ export const getSubstitutions = (segment, seq) => {
     }
   }
 
-
   if (segment.md) {
     const mdSubstitutions = parseMD(segment.md, false);
 
     mdSubstitutions.forEach(function (substitution) {
-      let posStart = substitution["pos"] + substitution["bamSeqShift"];
-      let posEnd = posStart + substitution["length"];
-      // When there is soft clipping at the beginning, 
+      let posStart = substitution['pos'] + substitution['bamSeqShift'];
+      let posEnd = posStart + substitution['length'];
+      // When there is soft clipping at the beginning,
       // we need to shift the position where we read the variant from the sequence
       // not necessary when there is hard clipping
-      if(softClippingAtReadStart !== null){
+      if (softClippingAtReadStart !== null) {
         posStart += softClippingAtReadStart.length;
         posEnd += softClippingAtReadStart.length;
       }
-      substitution["variant"] = seq.substring(posStart, posEnd);
-      delete substitution["bamSeqShift"];
+      substitution['variant'] = seq.substring(posStart, posEnd);
+      delete substitution['bamSeqShift'];
     });
 
     substitutions = mdSubstitutions.concat(substitutions);

--- a/src/bam-utils.js
+++ b/src/bam-utils.js
@@ -94,7 +94,6 @@ export const parseMD = (mdString, useCounts) => {
    */
 export const getSubstitutions = (segment, seq) => {
   let substitutions = [];
-  let insertions = 0;
   let softClippingAtReadStart = null;
 
   if (segment.cigar) {
@@ -113,7 +112,6 @@ export const getSubstitutions = (segment, seq) => {
 
         currPos += sub.length;
       } else if (sub.type === 'I') {
-        insertions += 1;
         substitutions.push({
           pos: currPos,
           length: 0.1,

--- a/src/index.html
+++ b/src/index.html
@@ -67,57 +67,21 @@ const testViewConfig =
   "exportViewUrl": "/api/v1/viewconfs",
   "views": [
     {
-      //"initialXDomain": [1069795,1070508],
-
-      // Variant + Soft Clipping (left)
-      "initialXDomain": [1558492965,1558493030],
-
-      // Insertions + Soft Clipping both sides
-      //"initialXDomain": [105706,105906],
-
-      // Hard Clipping (left and both sides)
-      //"initialXDomain": [145009,145409],
-
-      // Deletions
-      //"initialXDomain": [128870,129070],
-
+      "initialXDomain": [
+        667380253.9100767,
+        667380560.5316414
+      ],
       "initialYDomain": [
-        180520.26598912096,
-        180863.4346387336
+        -347192370.82304215,
+        -347192336.9332903
       ],
       "tracks": {
         "top": [
-          // {
-          //   "type": "pileup",
-          //   "uid": "WBTUIwm0SB2gcas7wzwztA",
-          //   "tilesetUid": "NLxWZTCoSzei1lkH4yVJmg",
-          //   "server": "https://resgen.io/api/v1",
-          //   "options": {
-          //     "axisPositionHorizontal": "right",
-          //     "axisLabelFormatting": "normal",
-          //     "outlineReadOnHover": false,
-          //     "showMousePosition": false,
-          //     "name": "HG002 Illumina (60x)",
-          //     "labelPosition": "bottomLeft",
-          //     "groupBy": null,
-          //     "colorScale": [
-          //       "#08519c",
-          //       "#6baed6",
-          //       "#993404",
-          //       "#fe9929",
-          //       "#808080",
-          //       "#DCDCDC"
-          //     ]
-          //   },
-          //   "width": 651,
-          //   "height": 362
-          // },
           {
-            "uid": "AdlJsUYFRzuJRZyYeKDX2A",
             "type": "chromosome-labels",
-            "width": 811,
-            "height": 30,
-            "server": "//higlass.io/api/v1",
+            "uid": "UP79_3WvQry1NYq2PTWrdQ",
+            "tilesetUid": "ZpZ8c5JJRUS1J7ZkofcUrg",
+            "server": "https://resgen.io/api/v1",
             "options": {
               "color": "#808080",
               "stroke": "#ffffff",
@@ -126,23 +90,17 @@ const testViewConfig =
               "showMousePosition": false,
               "mousePositionColor": "#000000"
             },
-            "filetype": "chromsizes-tsv",
-            "tilesetUid": "NyITQvZsS_mOFNlz5C2LJg"
+            "width": 20,
+            "height": 30
           },
           {
-            "uid": "fastaex",
-            "data": {
-              "type": "fasta",
-              "faiUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.fa.fai",
-              "fastaUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.fa",
-              "chromSizesUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.mod.chrom.sizes"
-            },
-            "type": "horizontal-sequence",
-            "width": 768,
-            "height": 25,
+            "type": "pileup",
+            "uid": "IKgXZbNGQPKocxDzCNgl5Q",
+            "tilesetUid": "D7zO4NiMTI-tn57HJKNORA",
+            "server": "http://localhost:8000/api/v1",
             "options": {
-              "name": "hg38",
-              "barBorder": true,
+              "axisPositionHorizontal": "right",
+              "axisLabelFormatting": "normal",
               "colorScale": [
                 "#08519c",
                 "#6baed6",
@@ -151,81 +109,42 @@ const testViewConfig =
                 "#808080",
                 "#DCDCDC"
               ],
-              "labelColor": "black",
-              "valueScaling": "linear",
-              "labelPosition": "topLeft",
-              "barBorderColor": "white",
-              "backgroundColor": "white",
-              "labelTextOpacity": 0.4,
-              "sortLargestOnTop": true,
-              "trackBorderColor": "white",
-              "trackBorderWidth": 0,
-              "extendedPreloading": false,
-              "colorAggregationMode": "none",
-              "notificationText": "Zoom in to see nucleotides...",
-              "fontSize": 16,
-              "fontFamily": "Arial",
-              "fontColor": "white",
-              "textOption": {
-                "fontSize": "32px",
-                "fontFamily": "Arial",
-                "fill": 16777215,
-                "fontWeight": "bold"
-              }
-            }
+              "outlineReadOnHover": false,
+              "showMousePosition": false,
+              "showCoverage": false,
+              "coverageHeight": 10,
+              "name": "https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/data/AshkenazimTrio/HG002_NA24385_son/NIST_HiSeq_HG002_Homogeneity-10953946/NHGRI_Illumina300X_AJtrio_novoalign_bams/HG002.GRCh38.60x.1.bam"
+            },
+            "width": 469,
+            "height": 262
           },
           {
-          "type": "pileup",
+            "type": "pileup",
+            "data": {
+              "type": "bam",
+              "url": "https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/data/AshkenazimTrio/HG002_NA24385_son/NIST_HiSeq_HG002_Homogeneity-10953946/NHGRI_Illumina300X_AJtrio_novoalign_bams/HG002.GRCh38.60x.1.bam",
+              "bamUrl": "https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/data/AshkenazimTrio/HG002_NA24385_son/NIST_HiSeq_HG002_Homogeneity-10953946/NHGRI_Illumina300X_AJtrio_novoalign_bams/HG002.GRCh38.60x.1.bam",
+              "baiUrl": "https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/data/AshkenazimTrio/HG002_NA24385_son/NIST_HiSeq_HG002_Homogeneity-10953946/NHGRI_Illumina300X_AJtrio_novoalign_bams/HG002.GRCh38.60x.1.bam.bai"
+            },
             "options": {
               "axisPositionHorizontal": "right",
               "axisLabelFormatting": "normal",
-              "outlineReadOnHover": "yes",
-              "groupBy": "strand",
-              "minusStrandColor": "#ffd1d4",
-              "plusStrandColor": "#cfd0ff",
-              "showCoverage": true,
               "colorScale": [
-                // A T G C N Other
                 "#08519c",
                 "#6baed6",
                 "#993404",
                 "#fe9929",
                 "#808080",
                 "#DCDCDC"
-              ]
+              ],
+              "outlineReadOnHover": false,
+              "showMousePosition": false,
+              "showCoverage": false,
+              "coverageHeight": 10
             },
-            "height": 500,
-            "uid": "FylkvVBTSumoJ959HT4-5B",
-            "data": {
-              "type": "bam",
-
-              // Caution: Example does not fit to the sequence track above.
-              // "url": "https://pkerp.s3.amazonaws.com/public/bamfile_test/SRR1770413.sorted.bam",
-              // "chromSizesUrl": "https://pkerp.s3.amazonaws.com/public/bamfile_test/GCF_000005845.2_ASM584v2_genomic.chrom.sizes",
-              
-              // Variant + Soft Clipping (left)
-              "bamUrl": "https://aveit.s3.amazonaws.com/higlass/bam/example_chr9_22004085.bam",
-              "baiUrl": "https://aveit.s3.amazonaws.com/higlass/bam/example_chr9_22004085.bam.bai",
-              "chromSizesUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.mod.chrom.sizes",
-
-              // Insertions + Soft Clipping both sides
-              // "bamUrl": "https://aveit.s3.amazonaws.com/higlass/bam/example_chr1_105806_S_I.bam",
-              // "baiUrl": "https://aveit.s3.amazonaws.com/higlass/bam/example_chr1_105806_S_I.bam.bai",
-              // "chromSizesUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.mod.chrom.sizes",
-
-              // Hard Clipping (left and both sides)
-              // "bamUrl": "https://aveit.s3.amazonaws.com/higlass/bam/example_chr1_145209_H.bam",
-              // "baiUrl": "https://aveit.s3.amazonaws.com/higlass/bam/example_chr1_145209_H.bam.bai",
-              // "chromSizesUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.mod.chrom.sizes",
-
-              // Deletions
-              // "bamUrl": "https://aveit.s3.amazonaws.com/higlass/bam/example_chr1_128970_D.bam",
-              // "baiUrl": "https://aveit.s3.amazonaws.com/higlass/bam/example_chr1_128970_D.bam.bai",
-              // "chromSizesUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.mod.chrom.sizes",
-
-
-            },
-            "width": 470
+            "width": 469,
+            "height": 277,
+            "uid": "JbH0k2NtRPmaDS-LLEOBDA"
           }
         ],
         "left": [],
@@ -241,7 +160,7 @@ const testViewConfig =
         "x": 0,
         "y": 0
       },
-      "uid": "WdlA7F8aTY2gXQzPGiBlwQ"
+      "uid": "BskxUboZT3qvih7oV_JY5A"
     }
   ],
   "zoomLocks": {

--- a/src/index.html
+++ b/src/index.html
@@ -67,21 +67,57 @@ const testViewConfig =
   "exportViewUrl": "/api/v1/viewconfs",
   "views": [
     {
-      "initialXDomain": [
-        667380253.9100767,
-        667380560.5316414
-      ],
+      //"initialXDomain": [1069795,1070508],
+
+      // Variant + Soft Clipping (left)
+      "initialXDomain": [1558492965,1558493030],
+
+      // Insertions + Soft Clipping both sides
+      //"initialXDomain": [105706,105906],
+
+      // Hard Clipping (left and both sides)
+      //"initialXDomain": [145009,145409],
+
+      // Deletions
+      //"initialXDomain": [128870,129070],
+
       "initialYDomain": [
-        -347192370.82304215,
-        -347192336.9332903
+        180520.26598912096,
+        180863.4346387336
       ],
       "tracks": {
         "top": [
+          // {
+          //   "type": "pileup",
+          //   "uid": "WBTUIwm0SB2gcas7wzwztA",
+          //   "tilesetUid": "NLxWZTCoSzei1lkH4yVJmg",
+          //   "server": "https://resgen.io/api/v1",
+          //   "options": {
+          //     "axisPositionHorizontal": "right",
+          //     "axisLabelFormatting": "normal",
+          //     "outlineReadOnHover": false,
+          //     "showMousePosition": false,
+          //     "name": "HG002 Illumina (60x)",
+          //     "labelPosition": "bottomLeft",
+          //     "groupBy": null,
+          //     "colorScale": [
+          //       "#08519c",
+          //       "#6baed6",
+          //       "#993404",
+          //       "#fe9929",
+          //       "#808080",
+          //       "#DCDCDC"
+          //     ]
+          //   },
+          //   "width": 651,
+          //   "height": 362
+          // },
           {
+            "uid": "AdlJsUYFRzuJRZyYeKDX2A",
             "type": "chromosome-labels",
-            "uid": "UP79_3WvQry1NYq2PTWrdQ",
-            "tilesetUid": "ZpZ8c5JJRUS1J7ZkofcUrg",
-            "server": "https://resgen.io/api/v1",
+            "width": 811,
+            "height": 30,
+            "server": "//higlass.io/api/v1",
             "options": {
               "color": "#808080",
               "stroke": "#ffffff",
@@ -90,17 +126,23 @@ const testViewConfig =
               "showMousePosition": false,
               "mousePositionColor": "#000000"
             },
-            "width": 20,
-            "height": 30
+            "filetype": "chromsizes-tsv",
+            "tilesetUid": "NyITQvZsS_mOFNlz5C2LJg"
           },
           {
-            "type": "pileup",
-            "uid": "IKgXZbNGQPKocxDzCNgl5Q",
-            "tilesetUid": "D7zO4NiMTI-tn57HJKNORA",
-            "server": "http://localhost:8000/api/v1",
+            "uid": "fastaex",
+            "data": {
+              "type": "fasta",
+              "faiUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.fa.fai",
+              "fastaUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.fa",
+              "chromSizesUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.mod.chrom.sizes"
+            },
+            "type": "horizontal-sequence",
+            "width": 768,
+            "height": 25,
             "options": {
-              "axisPositionHorizontal": "right",
-              "axisLabelFormatting": "normal",
+              "name": "hg38",
+              "barBorder": true,
               "colorScale": [
                 "#08519c",
                 "#6baed6",
@@ -109,42 +151,81 @@ const testViewConfig =
                 "#808080",
                 "#DCDCDC"
               ],
-              "outlineReadOnHover": false,
-              "showMousePosition": false,
-              "showCoverage": false,
-              "coverageHeight": 10,
-              "name": "https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/data/AshkenazimTrio/HG002_NA24385_son/NIST_HiSeq_HG002_Homogeneity-10953946/NHGRI_Illumina300X_AJtrio_novoalign_bams/HG002.GRCh38.60x.1.bam"
-            },
-            "width": 469,
-            "height": 262
+              "labelColor": "black",
+              "valueScaling": "linear",
+              "labelPosition": "topLeft",
+              "barBorderColor": "white",
+              "backgroundColor": "white",
+              "labelTextOpacity": 0.4,
+              "sortLargestOnTop": true,
+              "trackBorderColor": "white",
+              "trackBorderWidth": 0,
+              "extendedPreloading": false,
+              "colorAggregationMode": "none",
+              "notificationText": "Zoom in to see nucleotides...",
+              "fontSize": 16,
+              "fontFamily": "Arial",
+              "fontColor": "white",
+              "textOption": {
+                "fontSize": "32px",
+                "fontFamily": "Arial",
+                "fill": 16777215,
+                "fontWeight": "bold"
+              }
+            }
           },
           {
-            "type": "pileup",
+          "type": "pileup",
+            "options": {
+              "axisPositionHorizontal": "right",
+              "axisLabelFormatting": "normal",
+              "outlineReadOnHover": "yes",
+              "groupBy": "strand",
+              "minusStrandColor": "#ffd1d4",
+              "plusStrandColor": "#cfd0ff",
+              "showCoverage": true,
+              "colorScale": [
+                // A T G C N Other
+                "#08519c",
+                "#6baed6",
+                "#993404",
+                "#fe9929",
+                "#808080",
+                "#DCDCDC"
+              ]
+            },
+            "height": 500,
+            "uid": "FylkvVBTSumoJ959HT4-5B",
             "data": {
               "type": "bam",
-              "url": "https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/data/AshkenazimTrio/HG002_NA24385_son/NIST_HiSeq_HG002_Homogeneity-10953946/NHGRI_Illumina300X_AJtrio_novoalign_bams/HG002.GRCh38.60x.1.bam",
-              "bamUrl": "https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/data/AshkenazimTrio/HG002_NA24385_son/NIST_HiSeq_HG002_Homogeneity-10953946/NHGRI_Illumina300X_AJtrio_novoalign_bams/HG002.GRCh38.60x.1.bam",
-              "baiUrl": "https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/data/AshkenazimTrio/HG002_NA24385_son/NIST_HiSeq_HG002_Homogeneity-10953946/NHGRI_Illumina300X_AJtrio_novoalign_bams/HG002.GRCh38.60x.1.bam.bai"
+
+              // Caution: Example does not fit to the sequence track above.
+              // "url": "https://pkerp.s3.amazonaws.com/public/bamfile_test/SRR1770413.sorted.bam",
+              // "chromSizesUrl": "https://pkerp.s3.amazonaws.com/public/bamfile_test/GCF_000005845.2_ASM584v2_genomic.chrom.sizes",
+              
+              // Variant + Soft Clipping (left)
+              "bamUrl": "https://aveit.s3.amazonaws.com/higlass/bam/example_chr9_22004085.bam",
+              "baiUrl": "https://aveit.s3.amazonaws.com/higlass/bam/example_chr9_22004085.bam.bai",
+              "chromSizesUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.mod.chrom.sizes",
+
+              // Insertions + Soft Clipping both sides
+              // "bamUrl": "https://aveit.s3.amazonaws.com/higlass/bam/example_chr1_105806_S_I.bam",
+              // "baiUrl": "https://aveit.s3.amazonaws.com/higlass/bam/example_chr1_105806_S_I.bam.bai",
+              // "chromSizesUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.mod.chrom.sizes",
+
+              // Hard Clipping (left and both sides)
+              // "bamUrl": "https://aveit.s3.amazonaws.com/higlass/bam/example_chr1_145209_H.bam",
+              // "baiUrl": "https://aveit.s3.amazonaws.com/higlass/bam/example_chr1_145209_H.bam.bai",
+              // "chromSizesUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.mod.chrom.sizes",
+
+              // Deletions
+              // "bamUrl": "https://aveit.s3.amazonaws.com/higlass/bam/example_chr1_128970_D.bam",
+              // "baiUrl": "https://aveit.s3.amazonaws.com/higlass/bam/example_chr1_128970_D.bam.bai",
+              // "chromSizesUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.mod.chrom.sizes",
+
+
             },
-            "options": {
-              "axisPositionHorizontal": "right",
-              "axisLabelFormatting": "normal",
-              "colorScale": [
-                "#08519c",
-                "#6baed6",
-                "#993404",
-                "#fe9929",
-                "#808080",
-                "#DCDCDC"
-              ],
-              "outlineReadOnHover": false,
-              "showMousePosition": false,
-              "showCoverage": false,
-              "coverageHeight": 10
-            },
-            "width": 469,
-            "height": 277,
-            "uid": "JbH0k2NtRPmaDS-LLEOBDA"
+            "width": 470
           }
         ],
         "left": [],
@@ -160,7 +241,7 @@ const testViewConfig =
         "x": 0,
         "y": 0
       },
-      "uid": "BskxUboZT3qvih7oV_JY5A"
+      "uid": "WdlA7F8aTY2gXQzPGiBlwQ"
     }
   ],
   "zoomLocks": {


### PR DESCRIPTION
- Fix the previously broken rendering of resgen-server fetched data
  - Once that implementation and API is stable, we can copy it to higlass-server
- Added an option so that `showCoverage` can be set from the config menu 
- Fix insertion length output in mouseover text so that it doesn't always display (0.1)
- Various linting fixes

**Insertion length mouseover before**

![image](https://user-images.githubusercontent.com/2143629/102730456-d5268880-4302-11eb-87c8-cee7ae66e0b8.png)

**Insertion length mouseover after**

![image](https://user-images.githubusercontent.com/2143629/102730631-4e25e000-4303-11eb-96bf-1e34e5eb740b.png)

