### PR TITLE
Include clipped regions in row assignment calculation + new options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+v1.2.0
+
+- Soft and hard clipped regions are now included in the calculation of an appropriate row for a read. Without that, clipped regions would often overlap with other reads
+- New option `maxTileWidth` that controls when the "Zoom to see details" message is shown
+- New option `collapseWhenMaxTileWidthReached`. When this is set, the track height will be set to 20 when `maxTileWidth` is reached. This can be useful when there are a lot of tracks and you want to zoom out. With this option the pileup track will only take minimal space as long as you are zoomed out, so that it is easier to look at the other tracks.
+- Resolved some issues with a flickering "Zoom to see details" message.
+
 v1.0.1
 
 - Render BAM file tiles returned by resgen server

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "higlass-pileup",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "higlass-pileup",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "HiGlass Pileup Track",
   "keywords": [
     "HiGlass",

--- a/src/PileupTrack.js
+++ b/src/PileupTrack.js
@@ -367,8 +367,11 @@ varying vec4 vColor;
             });
             this.updateLoadingText();
 
-            if(this.maxTileWidthReached){
-              if (this.segmentGraphics && this.options.collapseWhenMaxTileWidthReached) {
+            if (this.maxTileWidthReached) {
+              if (
+                this.segmentGraphics &&
+                this.options.collapseWhenMaxTileWidthReached
+              ) {
                 this.pMain.removeChild(this.segmentGraphics);
               }
               this.loadingText.visible = false;
@@ -651,30 +654,33 @@ varying vec4 vColor;
           this.tilesetInfo,
         );
 
+        const DEFAULT_MAX_TILE_WIDTH = 2e5;
+
         if (
           tileWidth >
-          (this.tilesetInfo.max_tile_width || this.options.maxTileWidth)
+          (this.tilesetInfo.max_tile_width ||
+            this.options.maxTileWidth ||
+            DEFAULT_MAX_TILE_WIDTH)
         ) {
-          
-          if(this.options.collapseWhenMaxTileWidthReached){
-            this.pubSub.publish("trackDimensionsModified", {
+          if (this.options.collapseWhenMaxTileWidthReached) {
+            this.pubSub.publish('trackDimensionsModified', {
               height: 20,
               resizeParentDiv: true,
               trackId: this.trackId,
               viewId: this.viewId,
             });
           }
-          
+
           this.errorTextText = 'Zoom in to see details';
           this.drawError();
           this.animate();
           this.maxTileWidthReached = true;
           return;
-        }else{
+        } else {
           this.maxTileWidthReached = false;
 
-          if(this.options.collapseWhenMaxTileWidthReached){
-            this.pubSub.publish("trackDimensionsModified", {
+          if (this.options.collapseWhenMaxTileWidthReached) {
+            this.pubSub.publish('trackDimensionsModified', {
               height: this.originalHeight,
               resizeParentDiv: true,
               trackId: this.trackId,
@@ -881,7 +887,7 @@ PileupTrack.config = {
     'showCoverage',
     'coverageHeight',
     'maxTileWidth',
-    'collapseWhenMaxTileWidthReached'
+    'collapseWhenMaxTileWidthReached',
     // 'minZoom'
   ],
   defaultOptions: {
@@ -902,7 +908,7 @@ PileupTrack.config = {
     showCoverage: false,
     coverageHeight: 10, // unit: number of rows
     maxTileWidth: 2e5,
-    collapseWhenMaxTileWidthReached: false
+    collapseWhenMaxTileWidthReached: false,
   },
   optionsInfo: {
     outlineReadOnHover: {

--- a/src/PileupTrack.js
+++ b/src/PileupTrack.js
@@ -176,6 +176,11 @@ const PileupTrack = (HGC, ...args) => {
       super(context, options);
       context.dataFetcher.track = this;
 
+      this.trackId = this.id;
+      this.viewId = context.viewUid;
+      this.originalHeight = context.definition.height;
+      this.maxTileWidthReached = false;
+
       this.worker = worker;
       this.valueScaleTransform = HGC.libraries.d3Zoom.zoomIdentity;
 
@@ -356,10 +361,21 @@ varying vec4 vColor;
           )
           .then((toRender) => {
             this.loadingText.visible = false;
+
             fetchedTileKeys.forEach((x) => {
               this.rendering.delete(x);
             });
             this.updateLoadingText();
+
+            if(this.maxTileWidthReached){
+              if (this.segmentGraphics && this.options.collapseWhenMaxTileWidthReached) {
+                this.pMain.removeChild(this.segmentGraphics);
+              }
+              this.loadingText.visible = false;
+              this.draw();
+              this.animate();
+              return;
+            }
 
             this.errorTextText = null;
             this.pBorder.clear();
@@ -635,16 +651,36 @@ varying vec4 vColor;
           this.tilesetInfo,
         );
 
-        const DEFAULT_MAX_TILE_WIDTH = 2e5;
-
         if (
           tileWidth >
-          (this.tilesetInfo.max_tile_width || DEFAULT_MAX_TILE_WIDTH)
+          (this.tilesetInfo.max_tile_width || this.options.maxTileWidth)
         ) {
+          
+          if(this.options.collapseWhenMaxTileWidthReached){
+            this.pubSub.publish("trackDimensionsModified", {
+              height: 20,
+              resizeParentDiv: true,
+              trackId: this.trackId,
+              viewId: this.viewId,
+            });
+          }
+          
           this.errorTextText = 'Zoom in to see details';
           this.drawError();
           this.animate();
+          this.maxTileWidthReached = true;
           return;
+        }else{
+          this.maxTileWidthReached = false;
+
+          if(this.options.collapseWhenMaxTileWidthReached){
+            this.pubSub.publish("trackDimensionsModified", {
+              height: this.originalHeight,
+              resizeParentDiv: true,
+              trackId: this.trackId,
+              viewId: this.viewId,
+            });
+          }
         }
 
         this.errorTextText = null;
@@ -844,6 +880,8 @@ PileupTrack.config = {
     'minusStrandColor',
     'showCoverage',
     'coverageHeight',
+    'maxTileWidth',
+    'collapseWhenMaxTileWidthReached'
     // 'minZoom'
   ],
   defaultOptions: {
@@ -863,6 +901,8 @@ PileupTrack.config = {
     showMousePosition: false,
     showCoverage: false,
     coverageHeight: 10, // unit: number of rows
+    maxTileWidth: 2e5,
+    collapseWhenMaxTileWidthReached: false
   },
   optionsInfo: {
     outlineReadOnHover: {

--- a/src/bam-fetcher-worker.js
+++ b/src/bam-fetcher-worker.js
@@ -206,7 +206,7 @@ const bamRecordToJson = (bamRecord, chrName, chrOffset) => {
   segment.substitutions.forEach((sub) => {
     // left soft clipped region
     if((sub.type === "S" || sub.type === "H") && sub.pos < 0){
-      fromClippingAdjustment = (-1) * sub.length;
+      fromClippingAdjustment = -sub.length;
     }else if((sub.type === "S" || sub.type === "H") && sub.pos > 0){
       toClippingAdjustment = sub.length;
     }

--- a/src/bam-utils.js
+++ b/src/bam-utils.js
@@ -6,7 +6,7 @@ export const PILEUP_COLORS = {
   C: [1, 0, 0, 1], // red for c
   G: [0, 1, 0, 1], // green for g
   T: [1, 1, 0, 1], // yellow for T
-  S: [0, 0, 0, 0.4], // darker grey for soft clipping
+  S: [0, 0, 0, 0.4], // lighter grey for soft clipping
   H: [0, 0, 0, 0.5], // darker grey for hard clipping
   X: [0, 0, 0, 0.7], // black for unknown
   I: [1, 0, 1, 0.5], // purple for insertions

--- a/src/bam-utils.js
+++ b/src/bam-utils.js
@@ -6,7 +6,7 @@ export const PILEUP_COLORS = {
   C: [1, 0, 0, 1], // red for c
   G: [0, 1, 0, 1], // green for g
   T: [1, 1, 0, 1], // yellow for T
-  S: [0, 0, 0, 0.5], // darker grey for soft clipping
+  S: [0, 0, 0, 0.4], // darker grey for soft clipping
   H: [0, 0, 0, 0.5], // darker grey for hard clipping
   X: [0, 0, 0, 0.7], // black for unknown
   I: [1, 0, 1, 0.5], // purple for insertions

--- a/src/index.html
+++ b/src/index.html
@@ -70,10 +70,10 @@ const testViewConfig =
       //"initialXDomain": [1069795,1070508],
 
       // Variant + Soft Clipping (left)
-      "initialXDomain": [1558492965,1558493030],
+      //"initialXDomain": [1558492965,1558493030],
 
       // Insertions + Soft Clipping both sides
-      //"initialXDomain": [105706,105906],
+      "initialXDomain": [105706,105906],
 
       // Hard Clipping (left and both sides)
       //"initialXDomain": [145009,145409],
@@ -184,6 +184,8 @@ const testViewConfig =
               "minusStrandColor": "#ffd1d4",
               "plusStrandColor": "#cfd0ff",
               "showCoverage": true,
+              "maxTileWidth": 2e4,
+              "collapseWhenMaxTileWidthReached": true,
               "colorScale": [
                 // A T G C N Other
                 "#08519c",
@@ -194,7 +196,7 @@ const testViewConfig =
                 "#DCDCDC"
               ]
             },
-            "height": 500,
+            "height": 400,
             "uid": "FylkvVBTSumoJ959HT4-5B",
             "data": {
               "type": "bam",
@@ -204,14 +206,14 @@ const testViewConfig =
               // "chromSizesUrl": "https://pkerp.s3.amazonaws.com/public/bamfile_test/GCF_000005845.2_ASM584v2_genomic.chrom.sizes",
               
               // Variant + Soft Clipping (left)
-              "bamUrl": "https://aveit.s3.amazonaws.com/higlass/bam/example_chr9_22004085.bam",
-              "baiUrl": "https://aveit.s3.amazonaws.com/higlass/bam/example_chr9_22004085.bam.bai",
-              "chromSizesUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.mod.chrom.sizes",
+              // "bamUrl": "https://aveit.s3.amazonaws.com/higlass/bam/example_chr9_22004085.bam",
+              // "baiUrl": "https://aveit.s3.amazonaws.com/higlass/bam/example_chr9_22004085.bam.bai",
+              // "chromSizesUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.mod.chrom.sizes",
 
               // Insertions + Soft Clipping both sides
-              // "bamUrl": "https://aveit.s3.amazonaws.com/higlass/bam/example_chr1_105806_S_I.bam",
-              // "baiUrl": "https://aveit.s3.amazonaws.com/higlass/bam/example_chr1_105806_S_I.bam.bai",
-              // "chromSizesUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.mod.chrom.sizes",
+              "bamUrl": "https://aveit.s3.amazonaws.com/higlass/bam/example_chr1_105806_S_I.bam",
+              "baiUrl": "https://aveit.s3.amazonaws.com/higlass/bam/example_chr1_105806_S_I.bam.bai",
+              "chromSizesUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.mod.chrom.sizes",
 
               // Hard Clipping (left and both sides)
               // "bamUrl": "https://aveit.s3.amazonaws.com/higlass/bam/example_chr1_145209_H.bam",
@@ -226,7 +228,24 @@ const testViewConfig =
 
             },
             "width": 470
-          }
+          },
+          {
+            "uid": "AdlJsUYFRzuJRZyYeKDX2B",
+            "type": "chromosome-labels",
+            "width": 811,
+            "height": 30,
+            "server": "//higlass.io/api/v1",
+            "options": {
+              "color": "#808080",
+              "stroke": "#ffffff",
+              "fontSize": 12,
+              "fontIsLeftAligned": false,
+              "showMousePosition": false,
+              "mousePositionColor": "#000000"
+            },
+            "filetype": "chromsizes-tsv",
+            "tilesetUid": "NyITQvZsS_mOFNlz5C2LJg"
+          },
         ],
         "left": [],
         "center": [],


### PR DESCRIPTION
This PR includes the following changes:

- Soft and hard clipped regions are now included in the calculation of an appropriate row for a read. Without that, clipped regions would often overlap with other reads (see comparison below)
- new option `maxTileWidth` that controls when the "Zoom to see details" message is shown
- new option `collapseWhenMaxTileWidthReached`. When this is set, the track height will be set to 20 when `maxTileWidth` is reached. This can be useful when there are a lot of tracks and you want to zoom out. With this option the pileup track will only take minimal space as long as you are zoomed out, so that it is easier to look at the other tracks.
- Resolved some issues with a flickering "Zoom to see details" message.

Before:
![Screen Shot 2021-07-16 at 2 03 25 PM](https://user-images.githubusercontent.com/53857412/126008246-63a18b8f-6652-4725-b960-cc439b7b8b65.png)

After:
![Screen Shot 2021-07-16 at 2 02 25 PM](https://user-images.githubusercontent.com/53857412/126008269-f8859592-ce5a-48df-9e84-8470d38619a6.png)

