### PR TITLE
Max tile width option

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,12 @@ The live scripts can be found at:
             "data": {
               "type": "bam",
               "url": "https://pkerp.s3.amazonaws.com/public/bamfile_test/SRR1770413.sorted.bam",
-              "chromSizesUrl": "https://pkerp.s3.amazonaws.com/public/bamfile_test/GCF_000005845.2_ASM584v2_genomic.chrom.sizes"
+              "chromSizesUrl": "https://pkerp.s3.amazonaws.com/public/bamfile_test/GCF_000005845.2_ASM584v2_genomic.chrom.sizes",
+              {
+                "options": {
+                  "maxTileWidth": 30000
+                }
+              }
             },
             "width": 470
           }
@@ -99,6 +104,15 @@ The live scripts can be found at:
 - Save the viewconf as a JSON file.
 - Navigate to higlass.io/app and drag the JSON file onto the viewer.
 - Browse away!
+
+## Options
+
+### Data config
+
+**maxTileWidth** - To limit the amount of data that is fetched from the server, HiGlass sets a
+default maximum tile width. This can be modified in the `data` section of the track config. Setting
+it to a large file will let you zoom out further while still fetching data. This is useful for
+viewing low coverage BAM files.
 
 ## Support
 

--- a/src/PileupTrack.js
+++ b/src/PileupTrack.js
@@ -659,6 +659,7 @@ varying vec4 vColor;
         if (
           tileWidth >
           (this.tilesetInfo.max_tile_width ||
+            (this.dataFetcher.dataConfig.options && this.dataFetcher.dataConfig.options.maxTileWidth) ||
             this.options.maxTileWidth ||
             DEFAULT_MAX_TILE_WIDTH)
         ) {

--- a/src/bam-fetcher-worker.js
+++ b/src/bam-fetcher-worker.js
@@ -321,8 +321,6 @@ const init = (uid, bamUrl, baiUrl, chromSizesUrl, options) => {
     dataOptions[uid] = {...DEFAULT_DATA_OPTIONS, ...options}
   }
 
-  console.log('dataOptions', dataOptions[uid])
-
   if (!bamFiles[bamUrl]) {
     bamFiles[bamUrl] = new BamFile({
       bamUrl,
@@ -1145,9 +1143,6 @@ const renderSegments = (
     xScaleDomain: domain,
     xScaleRange: scaleRange,
   };
-
-  //const t2 = currTime();
-  //console.log('renderSegments time:', t2 - t1, 'ms');
 
   return Transfer(objData, [objData.positionsBuffer, colorsBuffer, ixBuffer]);
 };

--- a/src/bam-fetcher-worker.js
+++ b/src/bam-fetcher-worker.js
@@ -273,6 +273,8 @@ const tabularJsonToRowJson = (tabularJson) => {
 // promises indexed by urls
 const bamFiles = {};
 const bamHeaders = {};
+const dataOptions = {};
+
 
 const serverInfos = {};
 
@@ -308,7 +310,19 @@ const serverInit = (uid, server, tilesetUid, authHeader) => {
   };
 };
 
-const init = (uid, bamUrl, baiUrl, chromSizesUrl) => {
+const DEFAULT_DATA_OPTIONS = {
+  maxTileWidth: 2e5,
+}
+
+const init = (uid, bamUrl, baiUrl, chromSizesUrl, options) => {
+  if (!options) {
+    dataOptions[uid] = DEFAULT_DATA_OPTIONS;
+  } else {
+    dataOptions[uid] = {...DEFAULT_DATA_OPTIONS, ...options}
+  }
+
+  console.log('dataOptions', dataOptions[uid])
+
   if (!bamFiles[bamUrl]) {
     bamFiles[bamUrl] = new BamFile({
       bamUrl,
@@ -445,7 +459,8 @@ const tilesetInfo = (uid) => {
 };
 
 const tile = async (uid, z, x) => {
-  const MAX_TILE_WIDTH = 200000;
+  const {maxTileWidth} = dataOptions[uid];
+
   const { bamUrl, chromSizesUrl } = dataConfs[uid];
   const bamFile = bamFiles[bamUrl];
 
@@ -453,7 +468,7 @@ const tile = async (uid, z, x) => {
     const tileWidth = +tsInfo.max_width / 2 ** +z;
     const recordPromises = [];
 
-    if (tileWidth > MAX_TILE_WIDTH) {
+    if (tileWidth > maxTileWidth) {
       // this.errorTextText('Zoomed out too far for this track. Zoomin further to see reads');
       return new Promise((resolve) => resolve([]));
     }

--- a/src/bam-fetcher.js
+++ b/src/bam-fetcher.js
@@ -31,7 +31,7 @@ class BAMDataFetcher {
       }
 
       return tileFunctions
-        .init(this.uid, dataConfig.bamUrl, dataConfig.baiUrl, dataConfig.chromSizesUrl)
+        .init(this.uid, dataConfig.bamUrl, dataConfig.baiUrl, dataConfig.chromSizesUrl, dataConfig.options)
         .then(() => this.worker);
     });
   }

--- a/src/index.html
+++ b/src/index.html
@@ -223,7 +223,9 @@ const testViewConfig =
               // "baiUrl": "https://aveit.s3.amazonaws.com/higlass/bam/example_chr1_128970_D.bam.bai",
               // "chromSizesUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.mod.chrom.sizes",
 
-
+              "options": {
+                "maxTileWidth": 30000
+              }
             },
             "width": 470
           }


### PR DESCRIPTION
Added a `maxTileWidth` option to the dataConfig to let users zoom out further when viewing low coverage BAM files.

- [ ] Update the version number in unpkg link in README.md if building a new release
