### PR TITLE
Highlight abnormal insert sizes and mapping orientations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 - When hovering over the coverage, the genomic range that is covered by the bar is now displayed
 - Added the option `minMappingQuality` which takes an integer. If this is set, reads with a mapping quality lower than the specified value are not displayed.
+- Added the option `outlineMateOnHover`
+- Added the option `highlightReadsBy` which is an array can contain one or more of the value `insertSize`, `pairOrientation`, `insertSizeAndPairOrientation`. Details in the docs.
 
 v1.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+v1.4.0
+
 - When hovering over the coverage, the genomic range that is covered by the bar is now displayed
 - Added the option `minMappingQuality` which takes an integer. If this is set, reads with a mapping quality lower than the specified value are not displayed.
 - Added the option `outlineMateOnHover`

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ viewing low coverage BAM files.
 
 ### Track options
 
-**colorScale** - Array that controls the color of substitutions and highlighed reads. It can take 6 or 11 values. 11 values are required if you want to control highlighted read colors (see the `highlightReadsBy` option). Example:
+**colorScale** - Array that controls the color of substitutions and highlighted reads. It can take 6 or 11 values. 11 values are required if you want to control highlighted read colors (see the `highlightReadsBy` option). Example:
 ```
 "colorScale": [
   "#2c7bb6", //color of A substitutions

--- a/README.md
+++ b/README.md
@@ -116,19 +116,19 @@ viewing low coverage BAM files.
 
 ### Track options
 
-**outlineReadOnHover** Highlights the current read on hover.
+**outlineReadOnHover** - Highlights the current read on hover.
 
-**outlineMateOnHover** Highlights the mate of the current read on hover. If the mate is a split read, 
+**outlineMateOnHover** - Highlights the mate of the current read on hover. If the mate is a split read, 
 both alignments will be highlighted.
 
-**highlightReadsBy** Array that can take the values `insertSize`, `pairOrientation` or `insertSizeAndPairOrientation`:
+**highlightReadsBy** - Array that can take the values `insertSize`, `pairOrientation` or `insertSizeAndPairOrientation`:
 - if `insertSize` is set, reads that have a large or small insert size will be highlighted. The thresholds are controlled by the `largeInsertSizeThreshold` and `smallInsertSizeThreshold` track options. `largeInsertSizeThreshold` defaults to `1000`, i.e., 1000 bp.
 - if `pairOrientation` is set, reads with an abnormal mapping orientation are highlighted (e.g. ++,--,-+).
 - if `insertSizeAndPairOrientation` is set, reads with an abnormal mapping orientation that also have abnormal insert sizes are highlighted.
 - if multiple values are set, reads that fulfill any of the conditions are highlighed in the corresponding color.
 - highlight colors can be controlled by extending the `colorScale` track option to 11 values. The additional 5 values will control the large insert size color, small insert size color and the ++, --, -+ mapping orientations (in that order).
 
-**minMappingQuality** Integer. If this is set, reads with a mapping quality lower than the specified value are not displayed.
+**minMappingQuality** - If this is set (integer), reads with a mapping quality lower than the specified value are not displayed.
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -116,13 +116,30 @@ viewing low coverage BAM files.
 
 ### Track options
 
+**colorScale** - Array that controls the color of substitutions and highlighed reads. It can take 6 or 11 values. 11 values are required if you want to control highlighted read colors (see the `highlightReadsBy` option). Example:
+```
+"colorScale": [
+  "#2c7bb6", //color of A substitutions
+  "#92c5de", //color of T substitutions
+  "#ffffbf", //color of G substitutions
+  "#fdae61", //color of C substitutions
+  "#808080", //color of N substitutions
+  "#DCDCDC", //color of other substitutions
+  "#FF0000", //color of reads with large insert size
+  "#0000D1", //color of reads with small insert size
+  "#00D1D1", //color of reads with LL orientation (see https://software.broadinstitute.org/software/igv/interpreting_pair_orientations)
+  "#555CFA", //color of reads with RR orientation 
+  "#02A221", //color of reads with RL orientation 
+]
+```
+
 **outlineReadOnHover** - Highlights the current read on hover.
 
 **outlineMateOnHover** - Highlights the mate of the current read on hover. If the mate is a split read, 
 both alignments will be highlighted.
 
 **highlightReadsBy** - Array that can take the values `insertSize`, `pairOrientation` or `insertSizeAndPairOrientation`:
-- if `insertSize` is set, reads that have a large or small insert size will be highlighted. The thresholds are controlled by the `largeInsertSizeThreshold` and `smallInsertSizeThreshold` track options. `largeInsertSizeThreshold` defaults to `1000`, i.e., 1000 bp.
+- if `insertSize` is set, reads that have a large or small insert size will be highlighted. The thresholds are controlled by the `largeInsertSizeThreshold` and `smallInsertSizeThreshold` track options. `largeInsertSizeThreshold` defaults to `1000`, i.e., 1000 bp. `smallInsertSizeThreshold` is not set by default, i.e, reads with small insert size won't be highlighted.
 - if `pairOrientation` is set, reads with an abnormal mapping orientation are highlighted (e.g. ++,--,-+).
 - if `insertSizeAndPairOrientation` is set, reads with an abnormal mapping orientation that also have abnormal insert sizes are highlighted.
 - if multiple values are set, reads that fulfill any of the conditions are highlighed in the corresponding color.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,22 @@ default maximum tile width. This can be modified in the `data` section of the tr
 it to a large file will let you zoom out further while still fetching data. This is useful for
 viewing low coverage BAM files.
 
+### Track options
+
+**outlineReadOnHover** Highlights the current read on hover.
+
+**outlineMateOnHover** Highlights the mate of the current read on hover. If the mate is a split read, 
+both alignments will be highlighted.
+
+**highlightReadsBy** Array that can take the values `insertSize`, `pairOrientation` or `insertSizeAndPairOrientation`:
+- if `insertSize` is set, reads that have a large or small insert size will be highlighted. The thresholds are controlled by the `largeInsertSizeThreshold` and `smallInsertSizeThreshold` track options. `largeInsertSizeThreshold` defaults to `1000`, i.e., 1000 bp.
+- if `pairOrientation` is set, reads with an abnormal mapping orientation are highlighted (e.g. ++,--,-+).
+- if `insertSizeAndPairOrientation` is set, reads with an abnormal mapping orientation that also have abnormal insert sizes are highlighted.
+- if multiple values are set, reads that fulfill any of the conditions are highlighed in the corresponding color.
+- highlight colors can be controlled by extending the `colorScale` track option to 11 values. The additional 5 values will control the large insert size color, small insert size color and the ++, --, -+ mapping orientations (in that order).
+
+**minMappingQuality** Integer. If this is set, reads with a mapping quality lower than the specified value are not displayed.
+
 ## Support
 
 For questions, please either open an issue or ask on the HiGlass Slack channel at http://bit.ly/higlass-slack

--- a/package-lock.json
+++ b/package-lock.json
@@ -184,13 +184,13 @@
       "dev": true
     },
     "@gmod/bam": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@gmod/bam/-/bam-1.1.3.tgz",
-      "integrity": "sha512-oObhAGfoh+QeNny2n/kgzSn3jHrkwC5wB/8sa7N06eZZTh/qSkLV6IpaeiYCBE1YfsOWpXKZ9H6y9w7eBZz2VA==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@gmod/bam/-/bam-1.1.8.tgz",
+      "integrity": "sha512-ZMDGj64LEpfrA86NrjFnvL2Jl5vjqL7b2oyhS0+FX0XyMwl0BITI1/ocXx5d3jyVJNy/398Bvi7ploAvJOK7/w==",
       "requires": {
         "@babel/runtime-corejs3": "^7.5.5",
         "@gmod/bgzf-filehandle": "^1.3.3",
-        "abortable-promise-cache": "^1.2.0",
+        "abortable-promise-cache": "^1.4.0",
         "buffer-crc32": "^0.2.13",
         "cross-fetch": "^3.0.2",
         "es6-promisify": "^6.0.1",
@@ -202,9 +202,9 @@
       }
     },
     "@gmod/bgzf-filehandle": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@gmod/bgzf-filehandle/-/bgzf-filehandle-1.3.4.tgz",
-      "integrity": "sha512-wv008EwB2cx0ZEel+HB9iohpNFZfMbssukg8W3u5xweogaG22qnLjf57fbluAg3z8+lt0q3Hv4BCQNAMfCTNLg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@gmod/bgzf-filehandle/-/bgzf-filehandle-1.4.0.tgz",
+      "integrity": "sha512-qngK3UAXBc7mbjwfzyXuW5RIGCyfVenavShzOoHak+zoDM9+IrXAi1QP3aKQFk0YfWhFPmc7TQ/2HUiqnJbxpg==",
       "requires": {
         "@babel/runtime": "^7.3.4",
         "es6-promisify": "^6.0.1",
@@ -467,18 +467,18 @@
       "dev": true
     },
     "abortable-promise-cache": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/abortable-promise-cache/-/abortable-promise-cache-1.3.0.tgz",
-      "integrity": "sha512-GneJsLjdKirdN2xYkNoHg8oBMzRLYFyNMRRvfm5hEhz58kP3yUc4EGQ7+TZ/5AAgsb3N84pqhmRpWO46RamGpA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/abortable-promise-cache/-/abortable-promise-cache-1.4.1.tgz",
+      "integrity": "sha512-S0RbS0FPyqHcg2QXG+lYrzREpLsoZsbA3W0CIY4YHza2EKbfXcRAf5VMZRHG2BhA6UwK9EJx6OQvnW/X280/Lw==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "abortcontroller-polyfill": "^1.2.9"
       }
     },
     "abortcontroller-polyfill": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.5.0.tgz",
-      "integrity": "sha512-O6Xk757Jb4o0LMzMOMdWvxpHWrQzruYBaUruFaIOfAQRnWFxfdXYobw12jrVHGtoXk6WiiyYzc0QWN9aL62HQA=="
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.3.tgz",
+      "integrity": "sha512-zetDJxd89y3X99Kvo4qFx8GKlt6GsvN3UcRZHwU6iFA/0KiOmhkTVhe8oRoTBiTVPZu09x3vCra47+w8Yz1+2Q=="
     },
     "accepts": {
       "version": "1.3.7",
@@ -3320,9 +3320,9 @@
       }
     },
     "cross-fetch": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
-      "integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
+      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
       "requires": {
         "node-fetch": "2.6.1"
       }
@@ -5703,9 +5703,9 @@
       "dev": true
     },
     "generic-filehandle": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/generic-filehandle/-/generic-filehandle-2.0.3.tgz",
-      "integrity": "sha512-WP3SBaQ0vw9EESvILRZpJNoCssBI9Zpv5vnvqZzSCKn6DVHTP0jkuG64/ZErTASELnjMN3tRsWRY3PAZywGcjw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/generic-filehandle/-/generic-filehandle-2.2.1.tgz",
+      "integrity": "sha512-aI1uusDj0zrAvz8t7DfWKn2hjWEZBXhqW063MJB8gsvgCt8LOBJkuNOPXhWik237NMqI2m/ffQ4oKbaO+32vqg==",
       "requires": {
         "@babel/runtime": "^7.9.6",
         "es6-promisify": "^6.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "higlass-pileup",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "prerelease": "rm -rf dist/*; npm run build; zip -r dist.zip dist"
   },
   "dependencies": {
-    "@gmod/bam": "^1.1.3",
+    "@gmod/bam": "^1.1.8",
     "babel-cli": "^6.26.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "d3-array": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "higlass-pileup",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "HiGlass Pileup Track",
   "keywords": [
     "HiGlass",

--- a/src/PileupTrack.js
+++ b/src/PileupTrack.js
@@ -202,7 +202,7 @@ const PileupTrack = (HGC, ...args) => {
       this.readsById = {}; 
       this.previousTileIdsUsedForRendering = {};
 
-      this.prevOptions = {};
+      this.prevOptions = options;
 
       // graphics for highliting reads under the cursor
       this.mouseOverGraphics = new HGC.libraries.PIXI.Graphics();
@@ -348,7 +348,7 @@ varying vec4 vColor;
       }
 
       this.setUpShaderAndTextures();
-      // Reset the following so, the graphic actually updates
+      // Reset the following, so the graphic actually updates
       this.previousTileIdsUsedForRendering = {};
 
       // If one of the insertSize options changed, we need to regenerate the display.
@@ -378,7 +378,7 @@ varying vec4 vColor;
         return;
       }
 
-      // Prevent multiple renderings with the same tiles
+      // Prevent multiple renderings with the same tiles. This can happen when multiple new tiles come in at once
       if(eqSet(this.previousTileIdsUsedForRendering, fetchedTileIds)){
         return;
       }
@@ -436,7 +436,6 @@ varying vec4 vColor;
             const newGraphics = new HGC.libraries.PIXI.Graphics();
 
             this.prevRows = toRender.rows;
-            
             this.coverage = toRender.coverage;
             this.coverageSamplingDistance = toRender.coverageSamplingDistance;
 
@@ -636,7 +635,7 @@ varying vec4 vColor;
                   if (this.options.outlineMateOnHover) {
                     if (read.mate_id && read.mate_id in this.readsById) {
                       const mate = this.readsById[read.mate_id];
-                      // We assume mate height is the same, but width might be different
+                      // We assume the mate height is the same, but width might be different
                       const mate_width =
                         this._xScale(mate.to) - this._xScale(mate.from);
                       const mate_height =
@@ -1015,7 +1014,7 @@ PileupTrack.config = {
     axisPositionHorizontal: 'right',
     axisLabelFormatting: 'normal',
     colorScale: [
-      // A T G C N other LARGE_INSERT_SIZE SMALL_INSERT_SIZE
+      // A T G C N other
       '#08519c',
       '#6baed6',
       '#993404',

--- a/src/PileupTrack.js
+++ b/src/PileupTrack.js
@@ -696,16 +696,13 @@ varying vec4 vColor;
                       const insertSize = calculateInsertSize(read, mate);
                       let style = ``;
                       if (
-                        'largeInsertSizeThreshold' in this.options &&
-                        insertSize > this.options.largeInsertSizeThreshold
+                        ('largeInsertSizeThreshold' in this.options && insertSize > this.options.largeInsertSizeThreshold) ||
+                        ('smallInsertSizeThreshold' in this.options && insertSize < this.options.smallInsertSizeThreshold)
                       ) {
-                        style = `style="color:red;"`;
-                      } else if (
-                        'smallInsertSizeThreshold' in this.options &&
-                        insertSize < this.options.smallInsertSizeThreshold
-                      ) {
-                        style = `style="color:blue;"`;
-                      }
+                        const color = Object.keys(PILEUP_COLORS)[read.colorOverride || read.color];
+                        const htmlColor = this.colorArrayToString(PILEUP_COLORS[color]);
+                        style = `style="color:${htmlColor};"`;
+                      } 
                       insertSizeHtml = `Insert size: <span ${style}>${insertSize}</span><br>`;
                     }
                   }
@@ -719,12 +716,8 @@ varying vec4 vColor;
                   if (read.mappingOrientation) {
                     let style = ``;
                     if (read.colorOverride) {
-                      const color = Object.keys(PILEUP_COLORS)[
-                        read.colorOverride
-                      ];
-                      const htmlColor = this.colorArrayToString(
-                        PILEUP_COLORS[color],
-                      );
+                      const color = Object.keys(PILEUP_COLORS)[read.colorOverride];
+                      const htmlColor = this.colorArrayToString(PILEUP_COLORS[color]);
                       style = `style="color:${htmlColor};"`;
                     }
                     mappingOrientationHtml = `<span ${style}> Mapping orientation: ${read.mappingOrientation}</span><br>`;

--- a/src/bam-fetcher-worker.js
+++ b/src/bam-fetcher-worker.js
@@ -133,8 +133,8 @@ const findMates = (segments) => {
       if(segmentGroup.length === 2){
         const read = segmentGroup[0];
         const mate = segmentGroup[1];
-        read.mate_ids.push(mate.id);
-        mate.mate_ids.push(read.id);
+        read.mate_ids = [mate.id];
+        mate.mate_ids = [read.id];
       }
       else if(segmentGroup.length > 2){
         // It might be useful to distinguish reads from chimeric alignments in the future,
@@ -834,7 +834,7 @@ const renderSegments = (
   prevRows,
   trackOptions,
 ) => {
-  //const t1 = currTime();
+
   const allSegments = {};
   let allReadCounts = {};
   let coverageSamplingDistance;
@@ -1160,9 +1160,6 @@ const renderSegments = (
   const positionsBuffer = allPositions.slice(0, currPosition).buffer;
   const colorsBuffer = allColors.slice(0, currColor).buffer;
   const ixBuffer = allIndexes.slice(0, currIdx).buffer;
-
-  // const t2 = currTime();
-  // console.log(t2-t1);
 
   const objData = {
     rows: grouped,

--- a/src/bam-fetcher.js
+++ b/src/bam-fetcher.js
@@ -1,7 +1,7 @@
 const DEBOUNCE_TIME = 200;
 
 class BAMDataFetcher {
-  constructor(dataConfig, worker, HGC) {
+  constructor(dataConfig, trackOptions, worker, HGC) {
     this.dataConfig = dataConfig;
     this.uid = HGC.libraries.slugid.nice();
     this.worker = worker;
@@ -31,7 +31,7 @@ class BAMDataFetcher {
       }
 
       return tileFunctions
-        .init(this.uid, dataConfig.bamUrl, dataConfig.baiUrl, dataConfig.chromSizesUrl, dataConfig.options)
+        .init(this.uid, dataConfig.bamUrl, dataConfig.baiUrl, dataConfig.chromSizesUrl, dataConfig.options, trackOptions)
         .then(() => this.worker);
     });
   }

--- a/src/bam-utils.js
+++ b/src/bam-utils.js
@@ -12,6 +12,8 @@ export const PILEUP_COLORS = {
   I: [1, 0, 1, 0.5], // purple for insertions
   D: [1, 0.5, 0.5, 0.5], // pink-ish for deletions
   N: [1, 1, 1, 1],
+  LARGE_INSERT_SIZE: [1, 0, 0, 1], // Red for read pairs with large insert size
+  SMALL_INSERT_SIZE: [0, 0.24, 0.48, 1], // Dark blue for read pairs with large insert size
   BLACK: [0, 0, 0, 1],
   BLACK_05: [0, 0, 0, 0.5],
   PLUS_STRAND: [0.75, 0.75, 1, 1],
@@ -208,4 +210,33 @@ export const getSubstitutions = (segment, seq) => {
   }
 
   return substitutions;
+};
+
+/**
+ * Checks the track options and determines if mates need to be loaded
+ */
+export const areMatesRequired = (trackOptions) => {
+  return (
+    highlightAbnormalInsertSizes(trackOptions) ||
+    ('outlineMateOnHover' in trackOptions && trackOptions.outlineMateOnHover)
+  );
+};
+
+/**
+ * Checks the track options and determines insert sizes need to be examined
+ */
+ export const highlightAbnormalInsertSizes = (trackOptions) => {
+  return (
+    'smallInsertSizeThreshold' in trackOptions ||
+    'largeInsertSizeThreshold' in trackOptions 
+  );
+};
+
+/**
+ * Calculates insert size between read segements
+ */
+ export const calculateInsertSize = (segment1, segment2) => {
+  return segment1.from < segment2.from
+    ? Math.max(0, segment2.from - segment1.to)
+    : Math.max(0, segment1.from - segment2.to);
 };

--- a/src/bam-utils.js
+++ b/src/bam-utils.js
@@ -13,7 +13,10 @@ export const PILEUP_COLORS = {
   D: [1, 0.5, 0.5, 0.5], // pink-ish for deletions
   N: [1, 1, 1, 1],
   LARGE_INSERT_SIZE: [1, 0, 0, 1], // Red for read pairs with large insert size
-  SMALL_INSERT_SIZE: [0, 0.24, 0.48, 1], // Dark blue for read pairs with large insert size
+  SMALL_INSERT_SIZE: [0, 0.24, 0.48, 1], // Dark blue for read pairs with small insert size
+  LL: [0.15, 0.75, 0.75, 1], // cyan for Left-Left reads (see https://software.broadinstitute.org/software/igv/interpreting_pair_orientations)
+  RR: [0.18, 0.24, 0.8, 1], // darker blue for Right-Right reads
+  RL: [0, 0.5, 0.02, 1], // darker green for Right-Left reads
   BLACK: [0, 0, 0, 1],
   BLACK_05: [0, 0, 0, 0.5],
   PLUS_STRAND: [0.75, 0.75, 1, 1],
@@ -217,18 +220,8 @@ export const getSubstitutions = (segment, seq) => {
  */
 export const areMatesRequired = (trackOptions) => {
   return (
-    highlightAbnormalInsertSizes(trackOptions) ||
+    trackOptions.highlightReadsBy.length > 0 ||
     ('outlineMateOnHover' in trackOptions && trackOptions.outlineMateOnHover)
-  );
-};
-
-/**
- * Checks the track options and determines insert sizes need to be examined
- */
- export const highlightAbnormalInsertSizes = (trackOptions) => {
-  return (
-    'smallInsertSizeThreshold' in trackOptions ||
-    'largeInsertSizeThreshold' in trackOptions 
   );
 };
 

--- a/src/bam-utils.js
+++ b/src/bam-utils.js
@@ -221,7 +221,7 @@ export const getSubstitutions = (segment, seq) => {
 export const areMatesRequired = (trackOptions) => {
   return (
     trackOptions.highlightReadsBy.length > 0 ||
-    ('outlineMateOnHover' in trackOptions && trackOptions.outlineMateOnHover)
+    trackOptions.outlineMateOnHover
   );
 };
 


### PR DESCRIPTION
This PR adds new features that should facilitate the interpretation of structural variants:
- Added the option `outlineMateOnHover`
- Added the option `highlightReadsBy` which is an array can contain one or more of the value `insertSize`, `pairOrientation`, `insertSizeAndPairOrientation`. Details in the docs.

If one of these options is active, reads and mates are loaded from the BAM file (which requires more HTTP requests) and might have a slight negative effect on performance. It also requires identifying read/mate pairs, which requires an additional passing through the segments - in practice this is quite fast.

Reads with large insert size (deletion):
![image](https://user-images.githubusercontent.com/53857412/139501174-66a5ffa4-379f-4422-a9a3-6c6835f765d4.png)

Abnormal mapping orientation (duplication):
![image](https://user-images.githubusercontent.com/53857412/139501649-1a64fcd7-a019-436b-9e18-7e072c72198d.png)

Outline of hovered reads and mates (incl split reads):
![image](https://user-images.githubusercontent.com/53857412/139502353-b2f20074-5883-4010-854c-13afd056fb8c.png)

Display of insert sizes and mapping orientations in the tooltips:
![image](https://user-images.githubusercontent.com/53857412/139502550-00ddb58d-e851-4dce-b39b-f7379b6e786e.png)

Please let me know if you need a viewconf for testing.

- [ ] Update the version number in unpkg link in README.md if building a new release
