### PR TITLE
Fix alignment issue

### DIFF
--- a/src/PileupTrack.js
+++ b/src/PileupTrack.js
@@ -975,13 +975,6 @@ varying vec4 vColor;
       );
 
       const gSegment = document.createElement('g');
-
-      gSegment.setAttribute(
-        'transform',
-        `translate(${this.segmentGraphics.position.x},${this.segmentGraphics.position.y})` +
-          `scale(${this.segmentGraphics.scale.x},${this.segmentGraphics.scale.y})`,
-      );
-
       output.appendChild(gSegment);
 
       if (this.segmentGraphics) {

--- a/src/bam-fetcher-worker.js
+++ b/src/bam-fetcher-worker.js
@@ -383,6 +383,8 @@ const getCoverage = (uid, segmentList, samplingDistance) => {
 
   const { chromSizesUrl, bamUrl } = dataConfs[uid];
 
+  // getCoverage potentiall get calles before the chromInfos finished loading
+  // Exit the function in this case
   if(!chromInfos[chromSizesUrl]){
     return {
       coverage: coverage,

--- a/src/bam-fetcher-worker.js
+++ b/src/bam-fetcher-worker.js
@@ -381,6 +381,15 @@ const getCoverage = (uid, segmentList, samplingDistance) => {
   const coverage = {};
   let maxCoverage = 0;
 
+  const { chromSizesUrl, bamUrl } = dataConfs[uid];
+
+  if(!chromInfos[chromSizesUrl]){
+    return {
+      coverage: coverage,
+      maxCoverage: maxCoverage,
+    };
+  }
+
   for (let j = 0; j < segmentList.length; j++) {
     const from = segmentList[j].from;
     const to = segmentList[j].to;
@@ -422,7 +431,6 @@ const getCoverage = (uid, segmentList, samplingDistance) => {
     });
   }
 
-  const { chromSizesUrl, bamUrl } = dataConfs[uid];
   const absToChr = chromInfos[chromSizesUrl].absToChr;
   Object.entries(coverage).forEach(
       ([pos, entry]) => {
@@ -858,6 +866,25 @@ const renderSegments = (
   }
 
   prepareHighlightedReads(segmentList, trackOptions);
+
+  if (areMatesRequired(trackOptions)) {
+    // At this point reads are colored correctly, but we only want to align those reads that
+    // are within the visible tiles - not mates that are far away, as this can mess up the alignment
+    let tileMinPos = Number.MAX_VALUE;
+    let tileMaxPos = -Number.MAX_VALUE;
+    const tsInfo = tilesetInfos[uid];
+    tileIds.forEach((id) => {
+      const z = id.split('.')[0];
+      const x = id.split('.')[1];
+      const startEnd = tilesetInfoToStartEnd(tsInfo, +z, +x);
+      tileMinPos = Math.min(tileMinPos, startEnd[0]);
+      tileMaxPos = Math.max(tileMaxPos, startEnd[1]);
+    });
+
+    segmentList = segmentList.filter(
+      (segment) => segment.to >= tileMinPos && segment.from <= tileMaxPos,
+    );
+  }
   
   let [minPos, maxPos] = [Number.MAX_VALUE, -Number.MAX_VALUE];
 


### PR DESCRIPTION
When mates are loaded, only those reads that are within the visible tiles should go into the alignment algorithm, not mates that are potentially far away, as this can mess up the display. Mates that are far away are only aligned when they come into view.
