### PR TITLE
View reads as pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ The live scripts can be found at:
 
 - https://unpkg.com/higlass-pileup/dist/higlass-pileup.min.js
 
+## Things that haven't been thoroughly tested
+
+1. Group by strand when using single vs. paired end reads
+2. Group by HP tag when using single vs. paired end reads
+
 ### Client
 
 1. Make sure you load this track prior to `hglib.js`. For example:
@@ -118,6 +123,7 @@ viewing low coverage BAM files.
 ### Track options
 
 **colorScale** - Array that controls the color of substitutions and highlighted reads. It can take 6 or 11 values. 11 values are required if you want to control highlighted read colors (see the `highlightReadsBy` option). Example:
+
 ```
 "colorScale": [
   "#2c7bb6", //color of A substitutions
@@ -129,17 +135,18 @@ viewing low coverage BAM files.
   "#FF0000", //color of reads with large insert size
   "#0000D1", //color of reads with small insert size
   "#00D1D1", //color of reads with LL orientation (see https://software.broadinstitute.org/software/igv/interpreting_pair_orientations)
-  "#555CFA", //color of reads with RR orientation 
-  "#02A221", //color of reads with RL orientation 
+  "#555CFA", //color of reads with RR orientation
+  "#02A221", //color of reads with RL orientation
 ]
 ```
 
 **outlineReadOnHover** - Highlights the current read on hover.
 
-**outlineMateOnHover** - Highlights the mate of the current read on hover. If the mate is a split read, 
+**outlineMateOnHover** - Highlights the mate of the current read on hover. If the mate is a split read,
 both alignments will be highlighted.
 
 **highlightReadsBy** - Array that can take the values `insertSize`, `pairOrientation` or `insertSizeAndPairOrientation`:
+
 - if `insertSize` is set, reads that have a large or small insert size will be highlighted. The thresholds are controlled by the `largeInsertSizeThreshold` and `smallInsertSizeThreshold` track options. `largeInsertSizeThreshold` defaults to `1000`, i.e., 1000 bp. `smallInsertSizeThreshold` is not set by default, i.e, reads with small insert size won't be highlighted.
 - if `pairOrientation` is set, reads with an abnormal mapping orientation are highlighted (e.g. ++,--,-+).
 - if `insertSizeAndPairOrientation` is set, reads with an abnormal mapping orientation that also have abnormal insert sizes are highlighted.

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "scripts": {
     "build-es": "rm -rf ./es/* && npx babel ./src/ --out-dir ./es/ --env-name esm",
     "build": "npm run build-es && webpack --mode production",
-    "start": "webpack serve --mode development -c webpack.config.js",
+    "start": "webpack serve --mode development --port 8087 -c webpack.config.js",
     "prerelease": "rm -rf dist/*; npm run build; zip -r dist.zip dist"
   },
   "dependencies": {

--- a/src/PileupTrack.js
+++ b/src/PileupTrack.js
@@ -1,6 +1,11 @@
 import BAMDataFetcher from './bam-fetcher';
 import { spawn, BlobWorker } from 'threads';
-import { PILEUP_COLORS, cigarTypeToText, areMatesRequired, calculateInsertSize } from './bam-utils';
+import {
+  PILEUP_COLORS,
+  cigarTypeToText,
+  areMatesRequired,
+  calculateInsertSize,
+} from './bam-utils';
 
 import MyWorkerWeb from 'raw-loader!../dist/worker.js';
 
@@ -206,13 +211,11 @@ const PileupTrack = (HGC, ...args) => {
       this.pLabel.addChild(this.loadingText);
 
       this.externalInit(options);
-      
     }
 
-    // Some of the initialization code is factored out, so that we can 
+    // Some of the initialization code is factored out, so that we can
     // reset/reinitialize if an option change requires it
-    externalInit(options){
-
+    externalInit(options) {
       // we scale the entire view up until a certain point
       // at which point we redraw everything to get rid of
       // artifacts
@@ -236,7 +239,6 @@ const PileupTrack = (HGC, ...args) => {
 
       // graphics for highliting reads under the cursor
       this.mouseOverGraphics = new HGC.libraries.PIXI.Graphics();
-      
 
       this.fetching = new Set();
       this.rendering = new Set();
@@ -250,7 +252,6 @@ const PileupTrack = (HGC, ...args) => {
       }
 
       this.setUpShaderAndTextures();
-
     }
 
     initTile() {}
@@ -274,7 +275,11 @@ const PileupTrack = (HGC, ...args) => {
     setUpShaderAndTextures() {
       const colorDict = PILEUP_COLORS;
 
-      if (this.options && this.options.colorScale && this.options.colorScale.length == 6) {
+      if (
+        this.options &&
+        this.options.colorScale &&
+        this.options.colorScale.length == 6
+      ) {
         [
           colorDict.A,
           colorDict.T,
@@ -283,8 +288,11 @@ const PileupTrack = (HGC, ...args) => {
           colorDict.N,
           colorDict.X,
         ] = this.options.colorScale.map((x) => this.colorToArray(x));
-      }
-      else if (this.options && this.options.colorScale && this.options.colorScale.length == 11) {
+      } else if (
+        this.options &&
+        this.options.colorScale &&
+        this.options.colorScale.length == 11
+      ) {
         [
           colorDict.A,
           colorDict.T,
@@ -298,8 +306,10 @@ const PileupTrack = (HGC, ...args) => {
           colorDict.RR,
           colorDict.RL,
         ] = this.options.colorScale.map((x) => this.colorToArray(x));
-      } else if(this.options && this.options.colorScale){
-        console.error("colorScale must contain 6 or 11 entries. See https://github.com/higlass/higlass-pileup#options.")
+      } else if (this.options && this.options.colorScale) {
+        console.error(
+          'colorScale must contain 6 or 11 entries. See https://github.com/higlass/higlass-pileup#options.',
+        );
       }
 
       if (this.options && this.options.plusStrandColor) {
@@ -682,14 +692,21 @@ varying vec4 vColor;
                   }
 
                   const insertSizeHtml = this.getInsertSizeMouseoverHtml(read);
-                  const chimericReadHtml = read.mate_ids.length > 1 ? `<span style="color:red;">Chimeric alignment</span><br>`: ``;
+                  const chimericReadHtml =
+                    read.mate_ids.length > 1
+                      ? `<span style="color:red;">Chimeric alignment</span><br>`
+                      : ``;
 
                   let mappingOrientationHtml = ``;
                   if (read.mappingOrientation) {
                     let style = ``;
                     if (read.colorOverride) {
-                      const color = Object.keys(PILEUP_COLORS)[read.colorOverride];
-                      const htmlColor = this.colorArrayToString(PILEUP_COLORS[color]);
+                      const color = Object.keys(PILEUP_COLORS)[
+                        read.colorOverride
+                      ];
+                      const htmlColor = this.colorArrayToString(
+                        PILEUP_COLORS[color],
+                      );
                       style = `style="color:${htmlColor};"`;
                     }
                     mappingOrientationHtml = `<span ${style}> Mapping orientation: ${read.mappingOrientation}</span><br>`;
@@ -763,13 +780,11 @@ varying vec4 vColor;
       return '';
     }
 
-    getInsertSizeMouseoverHtml(read){
+    getInsertSizeMouseoverHtml(read) {
       let insertSizeHtml = ``;
       if (
         this.options.highlightReadsBy.includes('insertSize') ||
-        this.options.highlightReadsBy.includes(
-          'insertSizeAndPairOrientation',
-        )
+        this.options.highlightReadsBy.includes('insertSizeAndPairOrientation')
       ) {
         if (
           read.mate_ids.length === 1 &&
@@ -780,30 +795,32 @@ varying vec4 vColor;
           const insertSize = calculateInsertSize(read, mate);
           let style = ``;
           if (
-            ('largeInsertSizeThreshold' in this.options && insertSize > this.options.largeInsertSizeThreshold) ||
-            ('smallInsertSizeThreshold' in this.options && insertSize < this.options.smallInsertSizeThreshold)
+            ('largeInsertSizeThreshold' in this.options &&
+              insertSize > this.options.largeInsertSizeThreshold) ||
+            ('smallInsertSizeThreshold' in this.options &&
+              insertSize < this.options.smallInsertSizeThreshold)
           ) {
-            const color = Object.keys(PILEUP_COLORS)[read.colorOverride || read.color];
+            const color = Object.keys(PILEUP_COLORS)[
+              read.colorOverride || read.color
+            ];
             const htmlColor = this.colorArrayToString(PILEUP_COLORS[color]);
             style = `style="color:${htmlColor};"`;
-          } 
+          }
           insertSizeHtml = `Insert size: <span ${style}>${insertSize}</span><br>`;
         }
       }
       return insertSizeHtml;
     }
 
-    outlineMate(read, yScaleBand){
+    outlineMate(read, yScaleBand) {
       read.mate_ids.forEach((mate_id) => {
-        if(!this.readsById[mate_id]){
+        if (!this.readsById[mate_id]) {
           return;
         }
         const mate = this.readsById[mate_id];
         // We assume the mate height is the same, but width might be different
-        const mate_width =
-          this._xScale(mate.to) - this._xScale(mate.from);
-        const mate_height =
-          yScaleBand.bandwidth() * this.valueScaleTransform.k;
+        const mate_width = this._xScale(mate.to) - this._xScale(mate.from);
+        const mate_height = yScaleBand.bandwidth() * this.valueScaleTransform.k;
         const mate_xPos = this._xScale(mate.from);
         const mate_yPos = transformY(
           this.yScaleBands[mate.groupKey](mate.row),
@@ -821,7 +838,6 @@ varying vec4 vColor;
         );
       });
       this.animate();
-
     }
 
     calculateZoomLevel() {
@@ -1080,6 +1096,7 @@ PileupTrack.config = {
     'highlightReadsBy',
     'smallInsertSizeThreshold',
     'largeInsertSizeThreshold',
+    'viewAsPairs',
     // 'minZoom'
   ],
   defaultOptions: {
@@ -1104,7 +1121,8 @@ PileupTrack.config = {
     collapseWhenMaxTileWidthReached: false,
     minMappingQuality: 0,
     highlightReadsBy: [],
-    largeInsertSizeThreshold: 1000
+    largeInsertSizeThreshold: 1000,
+    viewAsPairs: false,
   },
   optionsInfo: {
     outlineReadOnHover: {
@@ -1141,28 +1159,19 @@ PileupTrack.config = {
           name: 'None',
         },
         insertSize: {
-          value: [
-            "insertSize"
-          ],
+          value: ['insertSize'],
           name: 'Insert size',
         },
         pairOrientation: {
-          value: [
-            "pairOrientation"
-          ],
+          value: ['pairOrientation'],
           name: 'Pair orientation',
         },
         insertSizeAndPairOrientation: {
-          value: [
-            "insertSizeAndPairOrientation"
-          ],
+          value: ['insertSizeAndPairOrientation'],
           name: 'Insert size and pair orientation',
         },
         insertSizeOrPairOrientation: {
-          value: [
-            "insertSize",
-            "pairOrientation"
-          ],
+          value: ['insertSize', 'pairOrientation'],
           name: 'Insert size or pair orientation',
         },
       },
@@ -1198,6 +1207,19 @@ PileupTrack.config = {
     },
     showCoverage: {
       name: 'Show coverage',
+      inlineOptions: {
+        yes: {
+          value: true,
+          name: 'Yes',
+        },
+        no: {
+          value: false,
+          name: 'No',
+        },
+      },
+    },
+    viewAsPairs: {
+      name: 'View as pairs',
       inlineOptions: {
         yes: {
           value: true,

--- a/src/bam-fetcher-worker.js
+++ b/src/bam-fetcher-worker.js
@@ -1275,21 +1275,23 @@ const renderSegments = (
           }
         });
 
-        for (let i = 1; i < section.segments.length; i++) {
-          // draw the rects connecting read pairs
-          const mate1End = xScale(section.segments[i - 1].toWithClipping);
-          const mate2Start = xScale(section.segments[i].fromWithClipping);
+        if (trackOptions.viewAsPairs) {
+          for (let i = 1; i < section.segments.length; i++) {
+            // draw the rects connecting read pairs
+            const mate1End = xScale(section.segments[i - 1].toWithClipping);
+            const mate2Start = xScale(section.segments[i].fromWithClipping);
 
-          let mateConnectorStart = Math.min(mate2Start, mate1End);
-          let mateConnectorEnd = Math.max(mate2Start, mate1End);
+            let mateConnectorStart = Math.min(mate2Start, mate1End);
+            let mateConnectorEnd = Math.max(mate2Start, mate1End);
 
-          addRect(
-            mateConnectorStart,
-            yTop + (7 * height) / 16,
-            mateConnectorEnd - mateConnectorStart,
-            height / 8,
-            PILEUP_COLOR_IXS.BLACK_05,
-          );
+            addRect(
+              mateConnectorStart,
+              yTop + (7 * height) / 16,
+              mateConnectorEnd - mateConnectorStart,
+              height / 8,
+              PILEUP_COLOR_IXS.BLACK_05,
+            );
+          }
         }
       });
     });

--- a/src/bam-utils.js
+++ b/src/bam-utils.js
@@ -221,14 +221,15 @@ export const getSubstitutions = (segment, seq) => {
 export const areMatesRequired = (trackOptions) => {
   return (
     trackOptions.highlightReadsBy.length > 0 ||
-    trackOptions.outlineMateOnHover
+    trackOptions.outlineMateOnHover ||
+    trackOptions.viewAsPairs
   );
 };
 
 /**
  * Calculates insert size between read segements
  */
- export const calculateInsertSize = (segment1, segment2) => {
+export const calculateInsertSize = (segment1, segment2) => {
   return segment1.from < segment2.from
     ? Math.max(0, segment2.from - segment1.to)
     : Math.max(0, segment1.from - segment2.to);

--- a/src/index.html
+++ b/src/index.html
@@ -124,12 +124,12 @@ const testViewConfig = {
         null
       ],
       "initialXDomain": [
-        3172213.649868534,
-        3175046.830623866
+        3170961.1256530066,
+        3171891.847932491
       ],
       "initialYDomain": [
-        -970663.4639309741,
-        -970663.4639309741
+        -971017.4263858083,
+        -970889.0955979686
       ]
     }
   ],
@@ -146,7 +146,6 @@ const testViewConfig = {
     "locksDict": {}
   }
 }
-
 window.hglib.viewer(
   document.getElementById('demo'),
   testViewConfig,

--- a/src/index.html
+++ b/src/index.html
@@ -74,7 +74,7 @@ const testViewConfig = {
           {
             "type": "pileup",
             "uid": "aa87f869-c8cd-4cf4-bbc7-91589e54cb90",
-            "height": 405,
+            "height": 605,
             "options": {
               "axisPositionHorizontal": "right",
               "axisLabelFormatting": "normal",
@@ -87,8 +87,8 @@ const testViewConfig = {
                 "#808080",
                 "#DCDCDC"
               ],
-              "outlineReadOnHover": false,
-              "outlineMateOnHover": false,
+              "outlineReadOnHover": true,
+              "outlineMateOnHover": true,
               "showMousePosition": false,
               "coverageHeight": 10,
               "maxTileWidth": 200000,

--- a/src/index.html
+++ b/src/index.html
@@ -57,193 +57,80 @@
 <script crossorigin src="https://unpkg.com/higlass-sequence/dist/higlass-sequence.js"></script>
 <script crossorigin src="https://unpkg.com/higlass@1.12.2/dist/hglib.min.js"></script>
 <script>
-const testViewConfig =
-{
+const testViewConfig = {
   "editable": true,
-  "trackSourceServers": [
-    "/api/v1",
-    "http://higlass.io/api/v1"
-  ],
-  "exportViewUrl": "/api/v1/viewconfs",
+  "viewEditable": true,
+  "tracksEditable": true,
   "views": [
     {
-      //"initialXDomain": [1069795,1070508],
-
-      // Variant + Soft Clipping (left)
-      "initialXDomain": [1558492965,1558493030],
-
-      // Insertions + Soft Clipping both sides
-      //"initialXDomain": [105706,105906],
-
-      // Hard Clipping (left and both sides)
-      //"initialXDomain": [145009,145409],
-
-      // Deletions
-      //"initialXDomain": [128870,129070],
-
-      "initialYDomain": [
-        180520.26598912096,
-        180863.4346387336
-      ],
+      "layout": {
+        "x": 0,
+        "y": 0,
+        "w": 12,
+        "h": 6
+      },
       "tracks": {
         "top": [
-          // {
-          //   "type": "pileup",
-          //   "uid": "WBTUIwm0SB2gcas7wzwztA",
-          //   "tilesetUid": "NLxWZTCoSzei1lkH4yVJmg",
-          //   "server": "https://resgen.io/api/v1",
-          //   "options": {
-          //     "axisPositionHorizontal": "right",
-          //     "axisLabelFormatting": "normal",
-          //     "outlineReadOnHover": false,
-          //     "showMousePosition": false,
-          //     "name": "HG002 Illumina (60x)",
-          //     "labelPosition": "bottomLeft",
-          //     "groupBy": null,
-          //     "colorScale": [
-          //       "#08519c",
-          //       "#6baed6",
-          //       "#993404",
-          //       "#fe9929",
-          //       "#808080",
-          //       "#DCDCDC"
-          //     ]
-          //   },
-          //   "width": 651,
-          //   "height": 362
-          // },
           {
-            "uid": "AdlJsUYFRzuJRZyYeKDX2A",
-            "type": "chromosome-labels",
-            "width": 811,
-            "height": 30,
-            "server": "//higlass.io/api/v1",
-            "options": {
-              "color": "#808080",
-              "stroke": "#ffffff",
-              "fontSize": 12,
-              "fontIsLeftAligned": false,
-              "showMousePosition": false,
-              "mousePositionColor": "#000000"
-            },
-            "filetype": "chromsizes-tsv",
-            "tilesetUid": "NyITQvZsS_mOFNlz5C2LJg"
-          },
-          {
-            "uid": "fastaex",
-            "data": {
-              "type": "fasta",
-              "faiUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.fa.fai",
-              "fastaUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.fa",
-              "chromSizesUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.mod.chrom.sizes"
-            },
-            "type": "horizontal-sequence",
-            "width": 768,
-            "height": 25,
-            "options": {
-              "name": "hg38",
-              "barBorder": true,
-              "colorScale": [
-                "#08519c",
-                "#6baed6",
-                "#993404",
-                "#fe9929",
-                "#808080",
-                "#DCDCDC"
-              ],
-              "labelColor": "black",
-              "valueScaling": "linear",
-              "labelPosition": "topLeft",
-              "barBorderColor": "white",
-              "backgroundColor": "white",
-              "labelTextOpacity": 0.4,
-              "sortLargestOnTop": true,
-              "trackBorderColor": "white",
-              "trackBorderWidth": 0,
-              "extendedPreloading": false,
-              "colorAggregationMode": "none",
-              "notificationText": "Zoom in to see nucleotides...",
-              "fontSize": 16,
-              "fontFamily": "Arial",
-              "fontColor": "white",
-              "textOption": {
-                "fontSize": "32px",
-                "fontFamily": "Arial",
-                "fill": 16777215,
-                "fontWeight": "bold"
-              }
-            }
-          },
-          {
-          "type": "pileup",
+            "type": "pileup",
+            "uid": "aa87f869-c8cd-4cf4-bbc7-91589e54cb90",
+            "height": 405,
             "options": {
               "axisPositionHorizontal": "right",
               "axisLabelFormatting": "normal",
-              "outlineReadOnHover": "yes",
-              "groupBy": "strand",
-              "minusStrandColor": "#ffd1d4",
-              "plusStrandColor": "#cfd0ff",
               "showCoverage": true,
               "colorScale": [
-                // A T G C N Other
-                "#08519c",
-                "#6baed6",
-                "#993404",
-                "#fe9929",
+                "#2c7bb6",
+                "#92c5de",
+                "#ffffbf",
+                "#fdae61",
                 "#808080",
                 "#DCDCDC"
-              ]
+              ],
+              "outlineReadOnHover": false,
+              "outlineMateOnHover": false,
+              "showMousePosition": false,
+              "coverageHeight": 10,
+              "maxTileWidth": 200000,
+              "collapseWhenMaxTileWidthReached": false,
+              "minMappingQuality": 0,
+              "highlightReadsBy": [],
+              "largeInsertSizeThreshold": 1000,
+              "viewAsPairs": true
             },
-            "height": 500,
-            "uid": "FylkvVBTSumoJ959HT4-5B",
             "data": {
               "type": "bam",
-
-              // Caution: Example does not fit to the sequence track above.
-              // "url": "https://pkerp.s3.amazonaws.com/public/bamfile_test/SRR1770413.sorted.bam",
-              // "chromSizesUrl": "https://pkerp.s3.amazonaws.com/public/bamfile_test/GCF_000005845.2_ASM584v2_genomic.chrom.sizes",
-              
-              // Variant + Soft Clipping (left)
-              "bamUrl": "https://aveit.s3.amazonaws.com/higlass/bam/example_chr9_22004085.bam",
-              "baiUrl": "https://aveit.s3.amazonaws.com/higlass/bam/example_chr9_22004085.bam.bai",
-              "chromSizesUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.mod.chrom.sizes",
-
-              // Insertions + Soft Clipping both sides
-              // "bamUrl": "https://aveit.s3.amazonaws.com/higlass/bam/example_chr1_105806_S_I.bam",
-              // "baiUrl": "https://aveit.s3.amazonaws.com/higlass/bam/example_chr1_105806_S_I.bam.bai",
-              // "chromSizesUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.mod.chrom.sizes",
-
-              // Hard Clipping (left and both sides)
-              // "bamUrl": "https://aveit.s3.amazonaws.com/higlass/bam/example_chr1_145209_H.bam",
-              // "baiUrl": "https://aveit.s3.amazonaws.com/higlass/bam/example_chr1_145209_H.bam.bai",
-              // "chromSizesUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.mod.chrom.sizes",
-
-              // Deletions
-              // "bamUrl": "https://aveit.s3.amazonaws.com/higlass/bam/example_chr1_128970_D.bam",
-              // "baiUrl": "https://aveit.s3.amazonaws.com/higlass/bam/example_chr1_128970_D.bam.bai",
-              // "chromSizesUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.mod.chrom.sizes",
-
+              "url": "https://pkerp.s3.amazonaws.com/public/bamfile_test/SRR1770413.sorted.bam",
+              "chromSizesUrl": "https://pkerp.s3.amazonaws.com/public/bamfile_test/GCF_000005845.2_ASM584v2_genomic.chrom.sizes",
               "options": {
                 "maxTileWidth": 30000
-              }
+              },
+              "bamUrl": "https://pkerp.s3.amazonaws.com/public/bamfile_test/SRR1770413.sorted.bam",
+              "baiUrl": "https://pkerp.s3.amazonaws.com/public/bamfile_test/SRR1770413.sorted.bam.bai"
             },
-            "width": 470
+            "width": 691
           }
         ],
-        "left": [],
         "center": [],
-        "bottom": [],
+        "left": [],
         "right": [],
+        "bottom": [],
         "whole": [],
         "gallery": []
       },
-      "layout": {
-        "w": 12,
-        "h": 6,
-        "x": 0,
-        "y": 0
-      },
-      "uid": "WdlA7F8aTY2gXQzPGiBlwQ"
+      "uid": "29d03d9f-bf38-45f3-b7b9-240e43a9c68a",
+      "zoomLimits": [
+        1,
+        null
+      ],
+      "initialXDomain": [
+        3172213.649868534,
+        3175046.830623866
+      ],
+      "initialYDomain": [
+        -970663.4639309741,
+        -970663.4639309741
+      ]
     }
   ],
   "zoomLocks": {


### PR DESCRIPTION
View reads as pairs. This will render mate pairs next to each other and draw a short line connecting them:

<img width="580" alt="image" src="https://github.com/user-attachments/assets/23f0fbfe-d2aa-4acf-842e-cfd8918e1e61">

- The option is enabled with the `viewAsPairs` viewconfig value.
- Unfortunately this change got mixed up with some formatting changes. The bulk of the change was in switching from rendering "segments" (single reads) as atomic units to rendering "sections" (groups of mates) as atomic units. Sections are placed in a row and the ends of the segments comprising them are connected.

- [ ] Update the version number in unpkg link in README.md if building a new release
